### PR TITLE
Add GitHub templates to align with other eq repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+### Expected behaviour
+
+### Actual behaviour
+
+### Steps to reproduce the behaviour
+
+### Technical information
+
+#### Browser
+
+#### Operating System
+
+### Screenshot

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### What is the context of this PR?
+Describe what you have changed and why.
+
+### How to review
+Describe the steps required to test the changes.
+
+- [ ] Do all commits have sensible commit messages?
+- [ ] Is there documentation or is the code self-describing?
+
+### Who worked on the PR
+
+Describe who worked on the changes, so that other people can review.


### PR DESCRIPTION
### What is the context of this PR?

Set the GitHub templates to match the other eq repos.
### How to review
- Check the .md files match and are sensible.
- [ ] Do all commits have sensible commit messages?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@collisdigital
